### PR TITLE
Enable template files on S3

### DIFF
--- a/server/src/controllers/pdfGenerator.ts
+++ b/server/src/controllers/pdfGenerator.ts
@@ -45,7 +45,7 @@ const pdfGenerator = ({ strapi }: { strapi: Core.Strapi }) => ({
     }
     let templateBytes = null;
     if (template.file.url.startsWith("http")) {
-      templateBytes = Buffer.from(await (await fetch(template2.file.url)).arrayBuffer());
+      templateBytes = Buffer.from(await (await fetch(template.file.url)).arrayBuffer());
     } else {
       templateBytes = fs.readFileSync(
         ctx.isTest ? template.file.url : `public${template.file.url}`

--- a/server/src/controllers/pdfGenerator.ts
+++ b/server/src/controllers/pdfGenerator.ts
@@ -43,9 +43,14 @@ const pdfGenerator = ({ strapi }: { strapi: Core.Strapi }) => ({
       );
       return;
     }
-    const templateBytes = fs.readFileSync(
-      ctx.isTest ? template.file.url : `public${template.file.url}`
-    );
+    let templateBytes = null;
+    if (template.file.url.startsWith("http")) {
+      templateBytes = Buffer.from(await (await fetch(template2.file.url)).arrayBuffer());
+    } else {
+      templateBytes = fs.readFileSync(
+        ctx.isTest ? template.file.url : `public${template.file.url}`
+      );
+    }
     const conf: Config = strapi.config.get(`plugin::${PLUGIN_ID}`);
     const genDoc = await strapi
       .plugin(PLUGIN_ID)


### PR DESCRIPTION
Quick'n'dirty (a bit) way to allow template PDFs to come from S3.